### PR TITLE
空指针问题修复（1.20.1分支）

### DIFF
--- a/src/main/java/com/zhichaoxi/applied_schematicannon/mixin/SchematicannonBlockEntityMixin.java
+++ b/src/main/java/com/zhichaoxi/applied_schematicannon/mixin/SchematicannonBlockEntityMixin.java
@@ -186,16 +186,24 @@ public abstract class SchematicannonBlockEntityMixin extends BlockEntity {
         // Find and remove
         boolean success = false;
         long amountFound = 0;
-        for (IGridNode cap : SchematicannonBlockEntityMixin$attachedMENetwork) {
-            if (cap != null)
-            {
-                MEStorage storage = cap.getGrid()
-                        .getStorageService().getInventory();
-                amountFound += storage.extract(AEItemKey.of(required.stack),
-                        required.stack.getCount(), Actionable.SIMULATE, SchematicannonActionHost);
+        for (InterfaceBlockEntity be : SchematicannonBlockEntityMixin$attachedMEInterface) {
+            InterfaceLogic logic = be.getInterfaceLogic();
+            IGridNode node = logic.getActionableNode();
+            if (node == null) {
+                continue;
             }
+
+            MEStorage storage = node.getGrid()
+                    .getStorageService().getInventory();
+            amountFound += storage.extract(AEItemKey.of(required.stack),
+                    required.stack.getCount(), Actionable.SIMULATE, SchematicannonActionHost);
             if (amountFound < required.stack.getCount())
             {
+                if (!skipMissing && logic.getInstalledUpgrades(AEItems.CRAFTING_CARD.asItem()) > 0) {
+                    ItemStack stack = required.stack.copy();
+                    stack.setCount(64);
+                    logic.getConfig().setStack(0, GenericStack.fromItemStack(stack));
+                }
                 continue;
             }
 
@@ -205,10 +213,13 @@ public abstract class SchematicannonBlockEntityMixin extends BlockEntity {
 
         if (!simulate && success) {
             amountFound = 0;
-            for (IGridNode cap : SchematicannonBlockEntityMixin$attachedMENetwork) {
-                if (cap != null)
-                {
-                    MEStorage storage = cap.getGrid()
+            for (InterfaceBlockEntity be : SchematicannonBlockEntityMixin$attachedMEInterface) {
+                if (be != null) {
+                    IGridNode node = be.getInterfaceLogic().getActionableNode();
+                    if (node == null) {
+                        continue;
+                    }
+                    MEStorage storage = node.getGrid()
                             .getStorageService().getInventory();
                     amountFound += storage.extract(AEItemKey.of(required.stack),
                             required.stack.getCount(), Actionable.MODULATE, SchematicannonActionHost);
@@ -220,7 +231,6 @@ public abstract class SchematicannonBlockEntityMixin extends BlockEntity {
                 break;
             }
         }
-
-        cir.setReturnValue(success);
+        if(success){cir.setReturnValue(success);}
     }
 }


### PR DESCRIPTION
非常好Mod，使我的蓝图炮旋转。

我修复了你的master和1.20.1分支的若干问题

1、蓝图炮从ME接口中提取物品时，有概率会遇到空指针问题，现在将Mixin代码中的extract和insert方法中传入的null修改为IActionSource SchematicannonActionHost = IActionSource.empty();避免空指针报错。（应用于master和1.20.1分支）

2、grabItemsFromAttachedInventories方法的注入点由TAIL修改为HEAD，现在能够正常地从ME接口里使用强力胶了。（应用于master和1.20.1分支）

3、我将你在新版本中写的缺少材料自动合成功能也写了进去。（应用于1.20.1分支）